### PR TITLE
Add pocket

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,6 @@
 class CollectionsController < BaseController
   def create
-    collection = Collection.new(collection_params.merge(route: route))
+    collection = Collection.new(collection_params.except(:pocket_serial_numbers).merge(route: route))
     serials = params[:pocket_serial_numbers]
     pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: Organization.first } }
     # The organization above is incorrect. It must be a global variable
@@ -19,6 +19,6 @@ class CollectionsController < BaseController
   end
 
   def collection_params
-    params.require(:collection).permit(:pocket_weigth, :date, :collection_point_id)
+    params.require(:collection).permit(:collection_point_id, :pocket_serial_numbers)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,7 +1,7 @@
 class CollectionsController < BaseController
   def create
     collection = Collection.new(collection_params.except(:pocket_serial_numbers).merge(route: route))
-    serials = params[:pocket_serial_numbers]
+    serials = params[:collection][:pocket_serial_numbers]
     pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: Organization.first } }
     # The organization above is incorrect. It must be a global variable
     collection.pockets.new(pockets)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,6 +1,10 @@
 class CollectionsController < BaseController
   def create
-    collection = Collection.new(collection_params)
+    collection = Collection.new(collection_params.merge(route: route))
+    serials = params[:pocket_serial_numbers]
+    pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: Organization.first } }
+    # The organization above is incorrect. It must be a global variable
+    collection.pockets.new(pockets)
     if collection.save
       head :ok
     else
@@ -15,6 +19,6 @@ class CollectionsController < BaseController
   end
 
   def collection_params
-    params.require(:collection).permit(:pocket_weight, :date, :collection_point_id)
+    params.require(:collection).permit(:pocket_weigth, :date, :collection_point_id)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,9 +1,9 @@
-class CollectionsController < BaseController
+class CollectionsController < AuthenticateController
   def create
     collection = Collection.new(collection_params.except(:pocket_serial_numbers).merge(route: route))
     serials = params[:collection][:pocket_serial_numbers]
-    pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: Organization.first } }
-    # The organization above is incorrect. It must be a global variable
+    pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: logged_user.organization } }
+    # The state above should not be assigned. It must be assigned by default in the database.
     collection.pockets.new(pockets)
     if collection.save
       head :ok

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -2,8 +2,7 @@ class CollectionsController < AuthenticateController
   def create
     collection = Collection.new(collection_params.except(:pocket_serial_numbers).merge(route: route))
     serials = params[:collection][:pocket_serial_numbers]
-    pockets = serials.collect { |s| { serial_number: s, state: 'Unweighed', organization: logged_user.organization } }
-    # The state above should not be assigned. It must be assigned by default in the database.
+    pockets = serials.collect { |s| { serial_number: s, organization: logged_user.organization } }
     collection.pockets.new(pockets)
     if collection.save
       head :ok

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,20 @@
+class CollectionsController < BaseController
+  def create
+    collection = Collection.new(collection_params)
+    if collection.save
+      head :ok
+    else
+      render_error(1, collection.errors)
+    end
+  end
+
+  private
+
+  def route
+    @route ||= Route.find(params[:route_id])
+  end
+
+  def collection_params
+    params.require(:collection).permit(:pocket_weight, :date, :collection_point_id)
+  end
+end

--- a/app/models/pocket.rb
+++ b/app/models/pocket.rb
@@ -1,5 +1,6 @@
 class Pocket < ApplicationRecord
   enum state: %i[Unweighed Weighed Classified]
+  validates :state, presence: true
 
   belongs_to :organization
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,6 @@ Rails.application.routes.draw do
     resources :collections, only: %i[create]
   end
 
-  resources :routes, only: [] do
-    resources :collections, only: %i[create]
-  end
-
   resources :bales, only: %i[index create show update]
 
   mount SwaggerUiEngine::Engine, at: '/api_docs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
   end
 
   resources :pockets, only: [:index]
+  
+  resources :routes, only: [] do
+    resources :collections, only: %i[create]
+  end
 
   resources :bales, only: %i[index create show update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
     resources :collections, only: %i[create]
   end
 
+  resources :routes, only: [] do
+    resources :collections, only: %i[create]
+  end
+
   resources :bales, only: %i[index create show update]
 
   mount SwaggerUiEngine::Engine, at: '/api_docs'

--- a/db/fixtures/collection_points.rb
+++ b/db/fixtures/collection_points.rb
@@ -1,0 +1,16 @@
+module Fixtures
+    COLLECTION_POINTS = [
+      {
+       latitude: '30.267153',
+       longitude: '-97.7430608'
+      },
+      {
+        latitude: '-13.843669',
+        longitude: '-60.894236'
+       },
+       {
+        latitude: '12.345678',
+        longitude: '98.765432'
+       }
+    ].freeze
+  end

--- a/db/fixtures/routes.rb
+++ b/db/fixtures/routes.rb
@@ -1,0 +1,17 @@
+module Fixtures
+    ROUTES = [
+      {
+       length: 13,
+       user_id: 1
+      },
+      {
+       length: 8,
+       user_id: 3
+      },
+      {
+       length: 5,
+       user_id: 1
+      }
+    ].freeze
+  end
+  

--- a/db/migrate/20180927231056_add_route_to_collections.rb
+++ b/db/migrate/20180927231056_add_route_to_collections.rb
@@ -1,0 +1,5 @@
+class AddRouteToCollections < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :collections, :route, foreign_key: true
+  end
+end

--- a/db/migrate/20180928221153_remove_pocket_weigth_from_collections.rb
+++ b/db/migrate/20180928221153_remove_pocket_weigth_from_collections.rb
@@ -1,0 +1,5 @@
+class RemovePocketWeigthFromCollections < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :collections, :pocket_weigth, :integer
+  end
+end

--- a/db/migrate/20180928221325_remove_date_from_collections.rb
+++ b/db/migrate/20180928221325_remove_date_from_collections.rb
@@ -1,0 +1,5 @@
+class RemoveDateFromCollections < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :collections, :date, :datetime
+  end
+end

--- a/db/migrate/20180928221937_add_pocket_weigth_to_collection_pockets.rb
+++ b/db/migrate/20180928221937_add_pocket_weigth_to_collection_pockets.rb
@@ -1,0 +1,5 @@
+class AddPocketWeigthToCollectionPockets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :collection_pockets, :pocket_weigth, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2018_09_30_214200) do
+=======
+ActiveRecord::Schema.define(version: 2018_09_28_221937) do
+>>>>>>> Database changed. Date and PocketWeigth removed from Collections. PocketWeigth added to CollectionPocket
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2018_09_30_214200) do
-=======
-ActiveRecord::Schema.define(version: 2018_09_28_221937) do
->>>>>>> Database changed. Date and PocketWeigth removed from Collections. PocketWeigth added to CollectionPocket
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2018_09_30_214200) do
     t.bigint "collection_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "pocket_weigth"
     t.index ["collection_id"], name: "index_collection_pockets_on_collection_id"
     t.index ["pocket_id"], name: "index_collection_pockets_on_pocket_id"
   end
@@ -70,12 +71,12 @@ ActiveRecord::Schema.define(version: 2018_09_30_214200) do
   end
 
   create_table "collections", force: :cascade do |t|
-    t.integer "pocket_weigth"
-    t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "collection_point_id"
+    t.bigint "route_id"
     t.index ["collection_point_id"], name: "index_collections_on_collection_point_id"
+    t.index ["route_id"], name: "index_collections_on_route_id"
   end
 
   create_table "devices", force: :cascade do |t|
@@ -129,6 +130,7 @@ ActiveRecord::Schema.define(version: 2018_09_30_214200) do
   add_foreign_key "collection_pockets", "collections"
   add_foreign_key "collection_pockets", "pockets"
   add_foreign_key "collections", "collection_points"
+  add_foreign_key "collections", "routes"
   add_foreign_key "devices", "organizations"
   add_foreign_key "devices", "users"
   add_foreign_key "pockets", "organizations"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,6 @@ require_relative 'fixtures/users'
 require_relative 'fixtures/routes'
 require_relative 'fixtures/collection_points'
 
-
-
 unless AdminUser.count.positive?
   Fixtures::ADMIN_USERS.each do |admin|
     AdminUser.create!(admin)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,10 @@
 require_relative 'fixtures/admin_users'
 require_relative 'fixtures/organizations'
 require_relative 'fixtures/users'
+require_relative 'fixtures/routes'
+require_relative 'fixtures/collection_points'
+
+
 
 unless AdminUser.count.positive?
   Fixtures::ADMIN_USERS.each do |admin|
@@ -20,5 +24,17 @@ end
 unless User.count.positive?
   Fixtures::USERS.each do |user|
     User.create!(user)
+  end
+end
+
+unless Route.count.positive?
+  Fixtures::ROUTES.each do |route|
+    Route.create!(route)
+  end
+end
+
+unless CollectionPoint.count.positive?
+  Fixtures::COLLECTION_POINTS.each do |collection_point|
+    CollectionPoint.create!(collection_point)
   end
 end

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -10,6 +10,7 @@ externalDocs:
 tags:
   - "Users"
   - "Bales"
+  - "Collections"
 
 paths:
   /organizations/{organization_id}/users:
@@ -187,6 +188,32 @@ paths:
           description: Unexpected error.
           schema:
             $ref: '#/definitions/Error'
+  /routes/{route_id}/collections:
+    post:
+      tags:
+        - "Collections"
+      operationId: addPocket
+      summary: Adds a pocket.
+      parameters:
+        - in: path
+          name: route_id
+          required: true
+          type: integer
+        - in: body
+          name: collection
+          schema:
+            $ref: '#/definitions/Collection'
+      responses:
+        200:
+          description: OK
+        404:
+          description: A route with the specified ID was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
 
   /pockets:
     get:
@@ -264,6 +291,22 @@ definitions:
       state:
         enum:
         - "Classified"
+  Collection:
+    type: object
+    required:
+      - collection_point_id
+      - pocket_serial_numbers
+    properties:
+      collection_point_id:
+        type: integer
+      pocket_serial_numbers:
+        type: array
+        items:
+          type: string
+    example:
+      collection_point_id: 1
+      pocket_serial_numbers: ['B17', 'B58']
+
   Error:
     type: object
     properties:

--- a/spec/controllers/bales_controller_spec.rb
+++ b/spec/controllers/bales_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BalesController, type: :controller do
         expect(response).to have_http_status(:bad_request)
       end
       it 'does not create bales without weight' do
-        create_bale_call(bale.weight, nil)
+        create_bale_call(nil, bale.material)
         expect(response).to have_http_status(:bad_request)
       end
     end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -11,19 +11,10 @@ RSpec.describe CollectionsController, type: :controller do
                               collection: { collection_point_id: cp_id, pocket_serial_numbers: serials } }
     end
 
-<<<<<<< HEAD
-    context 'when creating valid collections' do
-      it 'does return success' do
-        create_collection_call(route.id, collection_point.id, %w[B03 B17 B59])
-        expect(response).to have_http_status(:ok)
-      end
-    end
-=======
     context 'when the user is authenticated' do
       let!(:auth_user) { create_an_authenticated_user_with(organization, '1', 'android') }
       let!(:auth_route) { FactoryBot.create(:route, user: auth_user) }
       let(:invalid_route_id) { Route.pluck(:id).max + 1 }
->>>>>>> Collection controller test now test if the user is authenticated or not. Authentication added to addPocket
 
       context 'when creating valid collections' do
         it 'does return success' do

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe CollectionsController, type: :controller do
+  let(:json_response) { JSON.parse(response.body, symbolize_keys: true) }
+  let!(:organization) { FactoryBot.create(:organization) }
+  let!(:user) { FactoryBot.create(:user, organization: organization) }
+  let!(:route) { FactoryBot.create(:route, user: user) }
+  let!(:collection_point) { FactoryBot.create(:collection_point) }
+  let(:invalid_route_id) { Route.pluck(:id).max + 1 }
+
+  describe 'POST #create' do
+    def create_collection_call(r_id, cp_id, serials)
+      post :create, params: { route_id: r_id,
+                              collection: { collection_point_id: cp_id, pocket_serial_numbers: serials } }
+    end
+
+    context 'when creating valid collections' do
+      it 'does return success' do
+        create_collection_call(route.id, collection_point.id, %w[B03 B17 B59])
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when creating invalid collections' do
+      it 'does not create a collection without route_id' do
+        create_collection_call(invalid_route_id, collection_point.id, %w[B09 B33])
+        expect(response).to have_http_status(:not_found)
+      end
+      it 'does not create a collection without collection_point_id' do
+        create_collection_call(route.id, nil, %w[B11])
+        expect(response).to have_http_status(:bad_request)
+      end
+      it 'does not create a collection without pocket_serial_numbers' do
+        create_collection_call(route.id, collection_point.id, nil)
+        expect(response).to have_http_status(:internal_server_error)
+      end
+      it 'does not create a collection with empty pocket_serial_numbers' do
+        create_collection_call(route.id, collection_point.id, [])
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+  end
+end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe CollectionsController, type: :controller do
   let(:json_response) { JSON.parse(response.body, symbolize_keys: true) }
   let!(:organization) { FactoryBot.create(:organization) }
-  let!(:user) { FactoryBot.create(:user, organization: organization) }
-  let!(:route) { FactoryBot.create(:route, user: user) }
   let!(:collection_point) { FactoryBot.create(:collection_point) }
-  let(:invalid_route_id) { Route.pluck(:id).max + 1 }
 
   describe 'POST #create' do
     def create_collection_call(r_id, cp_id, serials)
@@ -14,29 +11,59 @@ RSpec.describe CollectionsController, type: :controller do
                               collection: { collection_point_id: cp_id, pocket_serial_numbers: serials } }
     end
 
+<<<<<<< HEAD
     context 'when creating valid collections' do
       it 'does return success' do
         create_collection_call(route.id, collection_point.id, %w[B03 B17 B59])
         expect(response).to have_http_status(:ok)
       end
     end
+=======
+    context 'when the user is authenticated' do
+      let!(:auth_user) { create_an_authenticated_user_with(organization, '1', 'android') }
+      let!(:auth_route) { FactoryBot.create(:route, user: auth_user) }
+      let(:invalid_route_id) { Route.pluck(:id).max + 1 }
+>>>>>>> Collection controller test now test if the user is authenticated or not. Authentication added to addPocket
 
-    context 'when creating invalid collections' do
-      it 'does not create a collection without route_id' do
-        create_collection_call(invalid_route_id, collection_point.id, %w[B09 B33])
-        expect(response).to have_http_status(:not_found)
+      context 'when creating valid collections' do
+        it 'does return success' do
+          create_collection_call(auth_route.id, collection_point.id, %w[B03 B17 B59])
+          expect(response).to have_http_status(:ok)
+        end
       end
-      it 'does not create a collection without collection_point_id' do
-        create_collection_call(route.id, nil, %w[B11])
-        expect(response).to have_http_status(:bad_request)
+
+      context 'when creating invalid collections' do
+        it 'does not create a collection without route_id' do
+          create_collection_call(invalid_route_id, collection_point.id, %w[B09 B33])
+          expect(response).to have_http_status(:not_found)
+        end
+        it 'does not create a collection without collection_point_id' do
+          create_collection_call(auth_route.id, nil, %w[B11])
+          expect(response).to have_http_status(:bad_request)
+        end
+        it 'does not create a collection without pocket_serial_numbers' do
+          create_collection_call(auth_route.id, collection_point.id, nil)
+          expect(response).to have_http_status(:internal_server_error)
+        end
+        it 'does not create a collection with empty pocket_serial_numbers' do
+          create_collection_call(auth_route.id, collection_point.id, [])
+          expect(response).to have_http_status(:internal_server_error)
+        end
       end
-      it 'does not create a collection without pocket_serial_numbers' do
-        create_collection_call(route.id, collection_point.id, nil)
-        expect(response).to have_http_status(:internal_server_error)
+    end
+
+    context 'when the user is not authenticated' do
+      let!(:no_auth_user) { FactoryBot.create(:user, organization: organization) }
+      let!(:no_auth_route) { FactoryBot.create(:route, user: no_auth_user) }
+
+      before(:each) { create_collection_call(no_auth_route.id, collection_point.id, %w[B03 B17 B59]) }
+
+      it 'does return an error' do
+        expect(response).to have_http_status(401)
       end
-      it 'does not create a collection with empty pocket_serial_numbers' do
-        create_collection_call(route.id, collection_point.id, [])
-        expect(response).to have_http_status(:internal_server_error)
+
+      it 'does render the right error' do
+        expect(json_response['error_code']).to eql 2
       end
     end
   end

--- a/spec/factories/collection_points.rb
+++ b/spec/factories/collection_points.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :collection_point do
-    latitude 'MyString'
-    longitude 'MyString'
+    latitude { Faker::Number.decimal(2, 6) }
+    longitude { Faker::Number.decimal(2, 6) }
   end
 end

--- a/spec/factories/collection_points.rb
+++ b/spec/factories/collection_points.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :collection_point do
-    latitude { Faker::Number.decimal(2, 6) }
-    longitude { Faker::Number.decimal(2, 6) }
+    latitude { Faker::Address.latitude }
+    longitude { Faker::Address.longitude }
   end
 end

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :route do
-    length 1
+    length { Faker::Number.number(2) }
     user nil
   end
 end


### PR DESCRIPTION
### Brief Description
Add pocket service for frontend.
### Related card or ticket
https://github.com/Pis-moove-it/reciclando-backend/issues/10
### Additional Details
Given a route_id, a collection_point_id and an array of pocket_serial_numbers, it creates a Collection associated to the ids mentioned, and create pockets with the serial numbers given associated to the collection too.
- Service for frontend
- Controller tests
- Swagger service
- Fixtures done for routes and collection points
