### PR TITLE
Service/edit serial number

### DIFF
--- a/app/controllers/pockets_controller.rb
+++ b/app/controllers/pockets_controller.rb
@@ -5,7 +5,7 @@ class PocketsController < AuthenticateController
 
   def edit_serial_number
     pocket = Pocket.find(params[:id])
-    return render_error(1, 'Missing serial number') if check_entry
+    return render_error(1, 'Missing serial number') if check_invalid_entry
 
     pocket.update!(serial_number: params['serial_number'])
     render json: pocket
@@ -13,7 +13,7 @@ class PocketsController < AuthenticateController
 
   private
 
-  def check_entry
+  def check_invalid_entry
     params['serial_number'].nil? || params['serial_number'].blank?
   end
 end

--- a/app/controllers/pockets_controller.rb
+++ b/app/controllers/pockets_controller.rb
@@ -1,5 +1,21 @@
 class PocketsController < AuthenticateController
+  skip_before_action :authenticated_user, only: :edit_serial_number
+
   def index
     render json: Pocket.unclassified.where(organization_id: logged_user.organization.id)
+  end
+
+  def edit_serial_number
+    pocket = Pocket.find(params[:id])
+    return render_error(1, 'Missing serial number') if check_entry
+
+    pocket.update!(serial_number: params['serial_number'])
+    render json: pocket
+  end
+
+  private
+
+  def check_entry
+    params['serial_number'].nil? || params['serial_number'].blank?
   end
 end

--- a/app/controllers/pockets_controller.rb
+++ b/app/controllers/pockets_controller.rb
@@ -1,6 +1,4 @@
 class PocketsController < AuthenticateController
-  skip_before_action :authenticated_user, only: :edit_serial_number
-
   def index
     render json: Pocket.unclassified.where(organization_id: logged_user.organization.id)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   resources :pockets, only: [:index] do
     member do
-      post :edit_serial_number
+      put :edit_serial_number
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :pockets, only: [:index]
+  resources :pockets, only: [:index] do
+    member do
+      post :edit_serial_number
+    end
+  end
 
   resources :routes, only: [] do
     resources :collections, only: %i[create]

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -243,6 +243,33 @@ paths:
           description: Unexpected error.
           schema:
             $ref: '#/definitions/Error'
+  /pockets/{id}/edit_serial_number:
+    post:
+      tags:
+        - "Pockets"
+      operationId: editSerialNumber
+      summary: Edit the serial number of pocket.
+      parameters:
+        - in: path
+          name: pocket_id
+          required: true
+          type: integer
+        - in: body
+          name: serial_number
+          schema:
+            $ref: '#/definitions/UnclassifiedPocket'
+      responses:
+        200:
+          description: Ok
+        404:
+          description: A pocket with specified Id was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
   /containers/{container_id}:
     put:
       tags:

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -248,7 +248,7 @@ paths:
       tags:
         - "Pockets"
       operationId: editSerialNumber
-      summary: Edit the serial number of pocket.
+      summary: Edit the serial number of a pocket.
       parameters:
         - in: path
           name: pocket_id
@@ -256,8 +256,12 @@ paths:
           type: integer
         - in: body
           name: serial_number
-          schema:
-            $ref: '#/definitions/UnclassifiedPocket'
+          required: true
+          type: integer
+        - in: body
+          name: ApiKey
+          required: true
+          type: string
       responses:
         200:
           description: Ok

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -257,7 +257,7 @@ paths:
         - in: body
           name: serial_number
           required: true
-          type: integer
+          type: string
         - in: body
           name: ApiKey
           required: true

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -243,7 +243,7 @@ paths:
           description: Unexpected error.
           schema:
             $ref: '#/definitions/Error'
-  /pockets/{id}/edit_serial_number:
+  /pockets/{pocket_id}/edit_serial_number:
     post:
       tags:
         - "Pockets"

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe OrganizationsController, type: :controller do
         create(:device, device_id: '1', device_type: 'android',
                         organization: another_organization)
       end
-
       before(:each) { organization_login_call('1', 'android', organization.name, 'password') }
 
       it 'should return success' do

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -70,4 +70,41 @@ RSpec.describe PocketsController, type: :controller do
       end
     end
   end
+
+  describe 'POST #edit_serial_number' do
+    let!(:pocket) { create(:pocket, organization: organization) }
+
+    def edit_serial_number_call(serial_number)
+      post :edit_serial_number, params: { id: pocket.id, serial_number: serial_number }
+    end
+
+    context 'when inputs are valid' do
+      before(:each) { edit_serial_number_call('123') }
+
+      it 'does edit the serial number' do
+        expect(json_response[:serial_number]).to eq '123'
+      end
+      it 'does return ok' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when pocket id is invalid' do
+      it 'does return not found' do
+        post :edit_serial_number, params: { id: Pocket.pluck(:id).max + 1, serial_number: 'serial_number' }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when serial number is invalid or missing' do
+      it 'does return bad request' do
+        post :edit_serial_number, params: { id: pocket.id }
+        expect(response).to have_http_status(400)
+      end
+      it 'does return bad request' do
+        post :edit_serial_number, params: { id: pocket.id, serial_number: '' }
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
 end

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe PocketsController, type: :controller do
   end
 
   describe 'POST #edit_serial_number' do
-    let!(:pocket) { create(:pocket, organization: organization) }
+    let!(:pocket) { create(:pocket, organization: organization, collection: collection) }
 
     def edit_serial_number_call(serial_number)
       post :edit_serial_number, params: { id: pocket.id, serial_number: serial_number }

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe PocketsController, type: :controller do
     end
 
     context 'when inputs are valid' do
-      before(:each) { edit_serial_number_call(pocket.id,'123',device.auth_token) }
+      before(:each) { edit_serial_number_call(pocket.id, '123', device.auth_token) }
       it 'does edit the serial number' do
         expect(json_response[:serial_number]).to eq '123'
       end

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -71,20 +71,20 @@ RSpec.describe PocketsController, type: :controller do
     end
   end
 
-  describe 'POST #edit_serial_number' do
+  describe 'PUT #edit_serial_number' do
     let!(:pocket) { create(:pocket, organization: organization, collection: collection) }
     let!(:device) do
       create(:device, device_id: '1', device_type: 'android',
                       organization: organization)
     end
 
-    def edit_serial_number_call(serial_number)
-      @request.headers['ApiKey'] = device.auth_token
-      post :edit_serial_number, params: { id: pocket.id, serial_number: serial_number }
+    def edit_serial_number_call(pocket_id, serial_number, token)
+      @request.headers['ApiKey'] = token
+      put :edit_serial_number, params: { id: pocket_id, serial_number: serial_number }
     end
 
     context 'when inputs are valid' do
-      before(:each) { edit_serial_number_call('123') }
+      before(:each) { edit_serial_number_call(pocket.id,'123',device.auth_token) }
       it 'does edit the serial number' do
         expect(json_response[:serial_number]).to eq '123'
       end
@@ -95,16 +95,15 @@ RSpec.describe PocketsController, type: :controller do
 
     context 'when ApiKey is missing' do
       it 'does return invalid token' do
-        post :edit_serial_number, params: { id: pocket.id, serial_number: '14592' }
+        put :edit_serial_number, params: { id: pocket.id, serial_number: '14592' }
         expect(response).to have_http_status(401)
       end
     end
 
     context 'when pocket id is invalid' do
       it 'does return not found' do
-        @request.headers['ApiKey'] = device.auth_token
         max_id = Pocket.pluck(:id).max
-        post :edit_serial_number, params: { id: max_id + 1, serial_number: '1', ApiKey: device.auth_token }
+        edit_serial_number_call(max_id + 1, '14592', device.auth_token)
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -112,12 +111,12 @@ RSpec.describe PocketsController, type: :controller do
     context 'when serial number is invalid or missing' do
       it 'does return bad request' do
         @request.headers['ApiKey'] = device.auth_token
-        post :edit_serial_number, params: { id: pocket.id }
+        put :edit_serial_number, params: { id: pocket.id }
         expect(response).to have_http_status(400)
       end
       it 'does return bad request' do
         @request.headers['ApiKey'] = device.auth_token
-        post :edit_serial_number, params: { id: pocket.id, serial_number: '' }
+        put :edit_serial_number, params: { id: pocket.id, serial_number: '' }
         expect(response).to have_http_status(400)
       end
     end


### PR DESCRIPTION
### Brief Description
Service to be consumed from front-end, serial number of a pocket can be edited.
### Related card or ticket
https://github.com/orgs/Pis-moove-it/projects/6#card-13303070
### Additional Details
ApiKey is required (authenticated service).
