### PR TITLE
Weigh pocket corrected

### DIFF
--- a/app/admin/pockets.rb
+++ b/app/admin/pockets.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Pocket do
-  permit_params :serial_number, :weight, :state
+  permit_params :serial_number, :weight
   actions :index, :show, :edit, :update
 
   index do
@@ -25,11 +25,7 @@ ActiveAdmin.register Pocket do
   form do |f|
     f.inputs do
       f.input :serial_number
-      if f.object.state != 'Unweighed'
-        f.input :weight
-      else
-        f.input :state
-      end
+      f.input :weight if f.object.state == 'Weighed'
     end
     f.actions
   end

--- a/app/controllers/pockets_controller.rb
+++ b/app/controllers/pockets_controller.rb
@@ -15,8 +15,7 @@ class PocketsController < AuthenticateController
   end
 
   def edit_weight
-    return render_error(1, 'Missing weight') if params[:weight].blank?
-    return render_error(1, 'Unweighead pocket') if pocket.Unweighed?
+    return render_error(1, 'Unweighed pocket') if pocket.Unweighed?
 
     if pocket.update(weight_params)
       render json: pocket
@@ -26,8 +25,7 @@ class PocketsController < AuthenticateController
   end
 
   def add_weight
-    return render_error(1, 'Missing weight') if params[:weight].blank?
-    return render_error(1, 'Weighead pocket') if pocket.Weighed?
+    return render_error(1, 'Weighed pocket') if pocket.Weighed?
 
     if pocket.update(weight_params.merge(state: 'Weighed'))
       render json: pocket

--- a/app/models/pocket.rb
+++ b/app/models/pocket.rb
@@ -5,7 +5,7 @@ class Pocket < ApplicationRecord
   belongs_to :collection
 
   validates :serial_number, presence: true
-  validates :weight, numericality: { greater_than: 0 }, allow_nil: true
+  validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0.001 }, unless: :unweighed?
 
   delegate :organization, to: :collection
 
@@ -17,5 +17,11 @@ class Pocket < ApplicationRecord
     def unclassified
       where(state: %w[Unweighed Weighed])
     end
+  end
+
+  private
+
+  def unweighed?
+    self.Unweighed?
   end
 end

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe PocketsController, type: :controller do
 
       let!(:auth_user) { create_an_authenticated_user_with(organization, '1', 'android') }
 
-      let!(:unclassified_pocket) do
-        create(:unclassified_pocket, collection: collection)
+      let!(:weighed_pocket) do
+        create(:weighed_pocket, collection: collection)
       end
-      let!(:second_unclassified_pocket) do
-        create(:unclassified_pocket, collection: collection)
+      let!(:unweighed_pocket) do
+        create(:unweighed_pocket, collection: collection)
       end
       let!(:classified_pocket) do
         create(:classified_pocket, collection: collection)
       end
-      let!(:another_unclassified_pocket) do
-        create(:unclassified_pocket, collection: another_collection)
+      let!(:another_unweighed_pocket) do
+        create(:unweighed_pocket, collection: another_collection)
       end
 
       before(:each) { list_pockets_call }
@@ -47,8 +47,8 @@ RSpec.describe PocketsController, type: :controller do
       end
 
       it 'does return all the unclassified pockets' do
-        expect(json_response).to eql [serializer.new(unclassified_pocket).as_json,
-                                      serializer.new(second_unclassified_pocket).as_json]
+        expect(json_response).to eql [serializer.new(weighed_pocket).as_json,
+                                      serializer.new(unweighed_pocket).as_json]
       end
 
       it 'does not return the classfied pockets' do
@@ -56,7 +56,7 @@ RSpec.describe PocketsController, type: :controller do
       end
 
       it 'does not return the pockets from another organization' do
-        expect(json_response.pluck(:id)).not_to include another_unclassified_pocket.id
+        expect(json_response.pluck(:id)).not_to include another_unweighed_pocket.id
       end
 
       context 'when listing paged pockets' do
@@ -67,8 +67,8 @@ RSpec.describe PocketsController, type: :controller do
         end
 
         it 'does return pockets as specified in the serializer' do
-          expect(json_response).to eql [serializer.new(unclassified_pocket).as_json,
-                                        serializer.new(second_unclassified_pocket).as_json]
+          expect(json_response).to eql [serializer.new(weighed_pocket).as_json,
+                                        serializer.new(unweighed_pocket).as_json]
         end
       end
     end

--- a/spec/factories/pockets.rb
+++ b/spec/factories/pockets.rb
@@ -7,10 +7,7 @@ FactoryBot.define do
 
   factory :classified_pocket, parent: :pocket do
     state { 'Classified' }
-  end
-
-  factory :unclassified_pocket, parent: :pocket do
-    state { %w[Unweighed Weighed].sample }
+    weight { Faker::Number.decimal(2, 2).to_f }
   end
 
   factory :weighed_pocket, parent: :pocket do

--- a/spec/models/pocket_spec.rb
+++ b/spec/models/pocket_spec.rb
@@ -29,12 +29,14 @@ RSpec.describe Pocket, type: :model do
       expect(pocket).not_to be_valid
     end
 
-    it 'is not valid with an invalid wieght' do
+    it 'is not valid when the pocket is weighed and weight is 0' do
+      pocket.state = 'Weighed'
       pocket.weight = 0
       expect(pocket).not_to be_valid
     end
 
-    it 'is not valid with an invalid wieght' do
+    it 'is not valid when the pocket is weighed and has negative weight' do
+      pocket.state = 'Weighed'
       pocket.weight = negative_weight
       expect(pocket).not_to be_valid
     end


### PR DESCRIPTION
### Brief Description
Fix the bug that occurred when you wanted to edit the weight of a pocket in active admin.
### Related card or ticket
https://github.com/Pis-moove-it/reciclando-backend/issues/144
### Additional Details
The inconsistency that was found in pockets with Weighed or Classified state and weight nil , is corrected.
