### PR TITLE
State filters added to pockets

### DIFF
--- a/app/admin/pockets.rb
+++ b/app/admin/pockets.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register Pocket do
 
   filter :serial_number
   filter :weight
-  filter :state
+  filter :state, as: :select, multiple: true, collection: Pocket.states
   filter :organization
 
   show title: :serial_number do


### PR DESCRIPTION
### Brief Description
It is allowed to filter by the state of a pocket (Weighed, Unweighed, Classified) in Active Admin system.
### Related card or ticket
https://github.com/Pis-moove-it/reciclando-backend/issues/162
### Additional Details
The filters are multiple.
