### PR TITLE
pockets returned ordered by their check_in

### DIFF
--- a/app/controllers/pockets_controller.rb
+++ b/app/controllers/pockets_controller.rb
@@ -1,6 +1,6 @@
 class PocketsController < AuthenticateController
   def index
-    query = Pocket.unclassified.where(organization_id: logged_user.organization.id)
+    query = Pocket.unclassified.where(organization_id: logged_user.organization.id).order('check_in desc')
     paginated_render(query)
   end
 

--- a/db/fixtures/pockets.rb
+++ b/db/fixtures/pockets.rb
@@ -17,6 +17,27 @@ module Fixtures
       weight: nil,
       organization_id: 1,
       collection_id: 1
+    },
+    {
+      serial_number: '123454',
+      weight: nil,
+      organization_id: 1,
+      collection_id: 1,
+      check_in: Time.current
+    },
+    {
+      serial_number: '123455',
+      weight: nil,
+      organization_id: 1,
+      collection_id: 1,
+      check_in: Time.current + 10
+    },
+    {
+      serial_number: '123456',
+      weight: nil,
+      organization_id: 1,
+      collection_id: 1,
+      check_in: Time.current + 20
     }
   ].freeze
 end

--- a/spec/controllers/pockets_controller_spec.rb
+++ b/spec/controllers/pockets_controller_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe PocketsController, type: :controller do
                                       serializer.new(unweighed_pocket).as_json]
       end
 
+      it 'does return the pockets ordered (desc) by check_in' do
+        expect(json_response.first[:check_in] > json_response.second[:check_in])
+      end
+
       it 'does not return the classfied pockets' do
         expect(json_response.pluck(:id)).not_to include classified_pocket.id
       end


### PR DESCRIPTION
### Brief Description
Return pockets ordered (descendent) by their check_in attribute.
### Related card or ticket
https://github.com/orgs/Pis-moove-it/projects/9#card-14555580