### PR TITLE
Update collection point recycled weights

### DIFF
--- a/app/models/collection_point.rb
+++ b/app/models/collection_point.rb
@@ -7,4 +7,11 @@ class CollectionPoint < ApplicationRecord
   before_validation(on: :create) do
     self.status = 'Ok' if status.nil? && type.eql?('Container')
   end
+
+  def classify(kg_trash, kg_plastic, kg_glass)
+    self.kg_trash += kg_trash
+    self.kg_recycled_plastic += kg_plastic
+    self.kg_recycled_glass += kg_glass
+    save
+  end
 end

--- a/app/models/pocket.rb
+++ b/app/models/pocket.rb
@@ -11,6 +11,8 @@ class Pocket < ApplicationRecord
 
   delegate :organization, to: :collection
 
+  delegate :collection_point, to: :collection
+
   before_validation(on: :create) do
     self.organization = organization
   end
@@ -43,11 +45,15 @@ class Pocket < ApplicationRecord
   end
 
   def classify(total_weight, kg_trash, kg_plastic, kg_glass)
+    # Calculates the amount of trash and recycled material in the pocket
     percentage = weight / total_weight.to_f
     self.kg_trash = kg_trash * percentage
     self.kg_recycled_plastic = kg_plastic * percentage
     self.kg_recycled_glass = kg_glass * percentage
+    # Changes the state of the pocket to Classified
     self.state = 'Classified'
+    # Updates recycled material and trash in container
+    collection_point.classify(self.kg_trash, kg_recycled_plastic, kg_recycled_glass)
   end
 
   private

--- a/spec/controllers/classification_controller_spec.rb
+++ b/spec/controllers/classification_controller_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe ClassificationController, type: :controller do
         let!(:another_collection) { create(:collection, route: another_route, collection_point: another_container) }
         let!(:another_weighed_pocket) { create(:weighed_pocket, collection: another_collection) }
 
+        def material_weights(array)
+          array.collect { |elem| [elem.kg_trash, elem.kg_recycled_plastic, elem.kg_recycled_glass] }
+        end
+
         before(:each) do
           classify_pockets_call(pockets.push(another_weighed_pocket).pluck(:id), kg_trash, kg_plastic, kg_glass)
           pockets.each(&:reload)
@@ -58,6 +62,10 @@ RSpec.describe ClassificationController, type: :controller do
 
         it 'does not classify pockets from another organization' do
           expect(another_weighed_pocket.state).not_to eql 'Classified'
+        end
+
+        it 'does classify collection_point of pockets' do
+          expect(material_weights([first_container, second_container].each(&:reload))).to eql material_weights(pockets)
         end
       end
 


### PR DESCRIPTION
### Brief Description
It updates collection points material weights when classifying some pockets collected there.
### Related card or ticket
https://github.com/Pis-moove-it/reciclando-backend/issues/187
### Additional Details
It updates collection points attributes `kg_trash`, `kg_recycled_plastic` and `kg_recycled_glass`
