### PR TITLE
Not ended routes are sent in route #index. Tests added

### DIFF
--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -27,7 +27,7 @@ class RoutesController < AuthenticateController
 
   def index
     return render_error(1, 'Invalid dates') unless valid_dates?
-    query = Route.where(date_query.merge(user_id: logged_user.organization.user_ids))
+    query = Route.ended.where(date_query.merge(user_id: logged_user.organization.user_ids))
     paginated_render(query)
   end
 

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -14,6 +14,12 @@ class Route < ApplicationRecord
     length.present?
   end
 
+  class << self
+    def ended
+      where.not(length: nil)
+    end
+  end
+
   private
 
   def check_in_pockets

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -241,10 +241,11 @@ RSpec.describe RoutesController, type: :controller do
       let(:another_organization) { create(:organization) }
       let!(:another_user) { create(:user, organization: another_organization) }
 
-      let!(:route) { create(:route, user: auth_user) }
-      let!(:second_route) { create(:route, user: auth_user) }
-      let!(:third_route) { create(:route, user: auth_user) }
-      let!(:another_route) { create :route, user: another_user }
+      let!(:route) { create(:ended_route, user: auth_user) }
+      let!(:second_route) { create(:ended_route, user: auth_user) }
+      let!(:third_route) { create(:ended_route, user: auth_user) }
+      let!(:not_ended_route) { create(:route, user: auth_user) }
+      let!(:another_route) { create :ended_route, user: another_user }
 
       context 'when listing all the routes from the organization' do
         before(:each) { get :index }
@@ -260,6 +261,10 @@ RSpec.describe RoutesController, type: :controller do
 
         it 'does not return routes from another organization' do
           expect(json_response.pluck(:id)).not_to include(another_route.id)
+        end
+
+        it 'does not return routes not ended' do
+          expect(json_response.pluck(:length)).not_to include(nil)
         end
       end
 
@@ -292,6 +297,10 @@ RSpec.describe RoutesController, type: :controller do
 
           it 'does not return routes from another organization' do
             expect(json_response.pluck(:id)).not_to include(another_route.id)
+          end
+
+          it 'does not return routes not ended' do
+            expect(json_response.pluck(:length)).not_to include(nil)
           end
         end
 


### PR DESCRIPTION
### Brief Description
Lists not ended routes.
### Related card or ticket
https://github.com/Pis-moove-it/reciclando-backend/issues/166
### Additional Details
It lists only not ended routes (`length` is not `nil`)
